### PR TITLE
E12S 수정

### DIFF
--- a/ui/raidboss/data/05-shb/raid/e12s.ts
+++ b/ui/raidboss/data/05-shb/raid/e12s.ts
@@ -32,8 +32,7 @@ type RelProp = {
 
 export interface Data extends RaidbossData {
   prsBlu?: boolean;
-  prsRealName?: string;
-  prsNickName?: string;
+  prsNick?: string;
   prsAggro?: string;
   prsTitanProp?: TitanProp[];
   prsStacker?: string[];
@@ -352,10 +351,11 @@ const sortPriority = (data: Data, party: string[]) => {
   } as const;
   type Pair = { prior: number; name: string };
   const pairs: Pair[] = [];
-  if (data.prsRealName !== undefined && data.prsNickName !== undefined) {
+  if (data.prsNick !== undefined) {
+    const sn = data.ShortName(data.me);
     for (const n of names) {
-      if (n === data.prsRealName)
-        pairs.push({ prior: jobNamePriority[data.prsNickName] ?? 8, name: n });
+      if (n === sn)
+        pairs.push({ prior: jobNamePriority[data.prsNick] ?? 8, name: n });
       else
         pairs.push({ prior: jobNamePriority[n] ?? 8, name: n });
     }
@@ -389,10 +389,11 @@ const sortRelativity = (data: Data, party: string[]) => {
   } as const;
   type Pair = { prior: number; name: string };
   const pairs: Pair[] = [];
-  if (data.prsRealName !== undefined && data.prsNickName !== undefined) {
+  if (data.prsNick !== undefined) {
+    const sn = data.ShortName(data.me);
     for (const n of names) {
-      if (n === data.prsRealName)
-        pairs.push({ prior: jobNamePriority[data.prsNickName] ?? 8, name: n });
+      if (n === sn)
+        pairs.push({ prior: jobNamePriority[data.prsNick] ?? 8, name: n });
       else
         pairs.push({ prior: jobNamePriority[n] ?? 8, name: n });
     }


### PR DESCRIPTION
외부 변수 prsNick과 prsBlu만 쓰게 바꿈

```typescript
// raidboss.js에 추가
// E12S
Options.Triggers.push({
    zoneId: ZoneId.EdensPromiseEternitySavage,
    triggers: [
        // 이름 설정 전반
        {
            id: 'E12S 전반 이니셜 리콜',
            type: 'Ability',
            netRegex: { source: 'Eden\'s Promise', id: '588C', capture: false },
            suppressSeconds: 5,
            run: (data) => {
                data.prsNick = 'D2';
                data.prsBlu = data.options.AutumnStyle && data.job === 'BLU';
            },
        },
        // 이름 설정 후반
        {
            id: 'E12S 후반 헬 저지먼트',
            type: 'StartsUsing',
            netRegex: { source: 'Oracle of Darkness', id: '58EF', capture: false },
            run: (data) => {
                data.prsNick = 'D2';
                data.prsBlu = data.options.AutumnStyle && data.job === 'BLU';
            },
        },
    ],
});
```
